### PR TITLE
Feature cjk support

### DIFF
--- a/docs/specs/2026-07-21-uax14-line-break-design.md
+++ b/docs/specs/2026-07-21-uax14-line-break-design.md
@@ -1,0 +1,476 @@
+# UAX #14 Line Breaking Implementation Design
+
+## Objective
+
+Implement Unicode Line Breaking Algorithm (UAX #14) for CJK + Latin core subset, enabling proper line break opportunities for mixed CJK/Latin text without relying on third-party crates.
+
+## Scope
+
+### In Scope
+- UAX #14 Line Break Classes: ID, AL, NU, OP, CL, QU, NS, IS, PR, PO, SY, SP, B2, CM, WJ, JL, JV, JT, HY, BA, BB, BK, CR, LF, NL, CB, EX, GL, ZW, ZWJ
+- Core pair rules: ID+ID, OP prohibition, CL prohibition, QU prohibition, Korean syllable (JL+JV/JT)
+- Integration with existing pdf.rs and layout.rs paths
+- Zero third-party dependency (core library stays pure std)
+
+### Out of Scope
+- Full 41-class implementation (Thai, Arabic, Devanagari rules)
+- Tailored line breaking (locale-specific overrides)
+- Word boundary detection (that's UAX #29)
+
+## Architecture
+
+### Module Structure
+
+```
+src/
+├── line_break.rs          # NEW: UAX #14 core implementation
+│   ├── LineBreakClass enum
+│   ├── LB_CLASS_RANGES table
+│   ├── line_break_class() function
+│   ├── LineBreakOpportunity struct
+│   └── line_break_opportunities() iterator
+├── pdf.rs                  # MODIFIED: use line_break_opportunities()
+└── layout.rs               # MODIFIED: optional use via feature flag
+```
+
+### LineBreakClass Enum
+
+Core subset of UAX #14 classes (20 classes covering CJK + Latin):
+
+```rust
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum LineBreakClass {
+    // Break opportunities
+    BK,  // Mandatory Break
+    CR,  // Carriage Return
+    LF,  // Line Feed
+    NL,  // Next Line
+    SP,  // Space
+    B2,  // Break Both
+    CB,  // Contingent Break
+    ZW,  // Zero Width Space
+    
+    // Prohibitions
+    GL,  // Non-breaking Glue (don't break before or after)
+    WJ,  // Word Joiner (don't break inside)
+    ZWJ, // Zero Width Joiner
+    
+    // CJK
+    ID,  // Ideographic
+    JL,  // Hangul Jamo Leading
+    JV,  // Hangul Jamo Vowel
+    JT,  // Hangul Jamo Trailing
+    
+    // Latin/General
+    AL,  // Alphabetic
+    NU,  // Numeric
+    OP,  // Open Punctuation
+    CL,  // Close Punctuation
+    QU,  // Quotation
+    NS,  // Numeric Start
+    IS,  // Infix Numeric Separator
+    PR,  // Prefix Numeric
+    PO,  // Postfix Numeric
+    SY,  // Break Symbols
+    HY,  // Hyphen
+    BA,  // Break After
+    BB,  // Break Before
+    EX,  // Exclamation
+    CM,  // Combining Mark
+    
+    // Fallback
+    XX,  // Unknown
+}
+```
+
+### Data Table Design
+
+Follow `unicode_punct.rs` pattern: sorted non-overlapping ranges with binary search.
+
+```rust
+/// Sorted, non-overlapping ranges of code points grouped by Line Break Class.
+/// Generated from Unicode 15.1.0 LineBreak.txt. Binary search for lookup.
+static LB_CLASS_RANGES: &[(u32, u32, LineBreakClass)] = &[
+    // Example entries (actual table generated from UCD)
+    (0x0000, 0x0009, LineBreakClass::BK),
+    (0x000A, 0x000A, LineBreakClass::LF),
+    (0x000B, 0x000C, LineBreakClass::BK),
+    (0x000D, 0x000D, LineBreakClass::CR),
+    (0x0020, 0x0020, LineBreakClass::SP),
+    // ... full table from LineBreak.txt
+    (0x4E00, 0x9FFF, LineBreakClass::ID),  // CJK Unified Ideographs
+    (0xAC00, 0xD7A3, LineBreakClass::ID),  // Hangul Syllables
+    // ...
+];
+```
+
+Estimated size: ~600-800 ranges, ~15-20KB binary footprint.
+
+### Classification Function
+
+```rust
+/// Returns the UAX #14 Line Break Class for a character.
+/// ASCII fast path, then binary search in LB_CLASS_RANGES.
+#[must_use]
+pub(crate) fn line_break_class(c: char) -> LineBreakClass {
+    // ASCII fast path: handle common cases inline
+    if c.is_ascii() {
+        return match c {
+            '\x00'..='\x09' | '\x0B'..='\x0C' => LineBreakClass::BK,
+            '\x0A' => LineBreakClass::LF,
+            '\x0D' => LineBreakClass::CR,
+            ' ' => LineBreakClass::SP,
+            '!' => LineBreakClass::EX,
+            '"' => LineBreakClass::QU,
+            '#' | '$' | '%' | '^' | '&' | '*' => LineBreakClass::PO,
+            '(' | '[' | '{' => LineBreakClass::OP,
+            ')' | ']' | '}' => LineBreakClass::CL,
+            '+' => LineBreakClass::PR,
+            ',' => LineBreakClass::IS,
+            '-' => LineBreakClass::HY,
+            '.' => LineBreakClass::IS,
+            '/' => LineBreakClass::SY,
+            '0'..='9' => LineBreakClass::NU,
+            ':' | ';' => LineBreakClass::IS,
+            '<' | '>' => LineBreakClass::QU,
+            '=' => LineBreakClass::AL,
+            'A'..='Z' | 'a'..='z' => LineBreakClass::AL,
+            '\\' | '|' => LineBreakClass::BA,
+            '_' => LineBreakClass::AL,
+            '~' => LineBreakClass::AL,
+            _ => LineBreakClass::XX,
+        };
+    }
+    
+    // Non-ASCII: binary search
+    let cp = c as u32;
+    LB_CLASS_RANGES
+        .binary_search_by(|&(lo, hi, _)| {
+            if cp < lo { Ordering::Greater }
+            else if cp > hi { Ordering::Less }
+            else { Ordering::Equal }
+        })
+        .map(|i| LB_CLASS_RANGES[i].2)
+        .unwrap_or(LineBreakClass::XX)
+}
+```
+
+### Line Break Opportunities
+
+```rust
+/// A line break opportunity with position and penalty hint.
+#[derive(Clone, Copy, Debug)]
+pub struct LineBreakOpportunity {
+    /// Character position (0-based) where break may occur.
+    /// Position N means break occurs BEFORE character at index N.
+    pub pos: usize,
+    /// Whether break is mandatory (BK, CR, LF, NL) or optional.
+    pub mandatory: bool,
+    /// Soft break type for penalty assignment.
+    pub break_type: BreakType,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BreakType {
+    /// CJK ideographic break (neutral penalty).
+    Ideographic,
+    /// Space break (free, preferred).
+    Space,
+    /// Hyphen break (light penalty).
+    Hyphen,
+    /// Break after (light penalty).
+    BreakAfter,
+    /// Break before (light penalty, rare).
+    BreakBefore,
+    /// Emergency fallback (heavy penalty).
+    Emergency,
+    /// Mandatory break (forced).
+    Mandatory,
+}
+
+/// Iterates over line break opportunities in text.
+/// Uses UAX #14 pair rules to determine break positions.
+pub fn line_break_opportunities(text: &str) -> LineBreakIterator<'_> {
+    LineBreakIterator::new(text)
+}
+
+pub struct LineBreakIterator<'a> {
+    chars: std::iter::Peekable<std::str::Chars<'a>>,
+    pos: usize,
+    prev_class: Option<LineBreakClass>,
+}
+
+impl<'a> Iterator for LineBreakIterator<'a> {
+    type Item = LineBreakOpportunity;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        // Core UAX #14 pair rule logic:
+        // 1. Get current char class
+        // 2. Apply pair rules with prev_class
+        // 3. Emit break opportunity if allowed
+        // 4. Update prev_class
+        
+        loop {
+            let c = self.chars.next()?;
+            let class = line_break_class(c);
+            let char_len = c.len_utf8();
+            
+            // ... pair rule logic ...
+            
+            self.pos += char_len;
+        }
+    }
+}
+```
+
+### Core Pair Rules
+
+Implement the most impactful rules from UAX #14:
+
+```rust
+fn can_break_between(prev: LineBreakClass, next: LineBreakClass) -> bool {
+    match (prev, next) {
+        // Mandatory breaks
+        (BK | CR | LF | NL, _) => true,
+        (_, BK | CR | LF | NL) => true,
+        
+        // ZW creates break opportunity
+        (ZW, _) => true,
+        
+        // Space: break after
+        (SP, _) => true,
+        (_, SP) => false, // break after space, not before
+        
+        // Don't break inside QU (quotes)
+        (QU, _) if !matches!(next, SP | ZW | BK | CR | LF | NL) => false,
+        (_, QU) if !matches!(prev, SP | ZW | BK | CR | LF | NL) => false,
+        
+        // Don't break before OP (open punctuation)
+        (_, OP) => false,
+        
+        // Don't break after CL (close punctuation)
+        (CL, _) => false,
+        
+        // Don't break after EX (exclamation)
+        (EX, _) => false,
+        
+        // Don't break before EX (exclamation)
+        (_, EX) => false,
+        
+        // Don't break before NS (numeric start)
+        (_, NS) => false,
+        
+        // Don't break after PR (prefix numeric) before numeric
+        (PR, NU) => false,
+        
+        // Don't break after PO (postfix numeric) before numeric
+        (PO, NU) => false,
+        
+        // Don't break before PR after numeric
+        (NU, PR) => false,
+        
+        // Don't break before PO after numeric
+        (NU, PO) => false,
+        
+        // ID + ID: break allowed between ideographs
+        (ID, ID) => true,
+        (ID, AL | NU) => true,
+        (AL | NU, ID) => true,
+        
+        // Korean syllable formation: don't break
+        (JL, JL | JV | H2 | H3) => false,
+        (JV | H2, JV | JT) => false,
+        (JT | H3, JT) => false,
+        
+        // B2: break both sides
+        (B2, _) => true,
+        (_, B2) => true,
+        
+        // HY/BA: break after
+        (HY | BA, _) => true,
+        
+        // BB: break before
+        (_, BB) => true,
+        
+        // Default: allow break (XX, AL, etc.)
+        _ => true,
+    }
+}
+```
+
+### Penalty Mapping
+
+Map `BreakType` to Knuth-Plass penalty values:
+
+| BreakType | Penalty | Reason |
+|-----------|---------|--------|
+| Mandatory | -∞ (forced) | Forced break |
+| Space | 0 | Preferred break point |
+| Ideographic | 0 | Neutral, natural CJK break |
+| Hyphen | 50 | Slight cost (hyphen renders) |
+| BreakAfter | 80 | Less preferred |
+| BreakBefore | 100 | Rare, stylistic |
+| Emergency | 2000 | Last resort |
+
+## Integration
+
+### pdf.rs Changes
+
+Replace current word break logic in `flush_pdf_word`:
+
+```rust
+// BEFORE: pdf_word_break_points() with simple CJK detection
+// AFTER: line_break_opportunities() with UAX #14 rules
+
+fn flush_pdf_word(built: &mut BuiltParagraph, word: &mut Vec<Tok>, cx: PdfWordContext<'_>) {
+    // ... existing stats computation ...
+    
+    let chars = pdf_word_chars(word, stats.char_len);
+    let text: String = chars.iter().collect();
+    
+    // Get UAX #14 break opportunities
+    let uax_breaks: Vec<LineBreakOpportunity> = line_break_opportunities(&text).collect();
+    
+    // Convert to PdfBreakPoint with penalties
+    let mut points: Vec<PdfBreakPoint> = uax_breaks
+        .into_iter()
+        .filter(|b| !b.mandatory) // skip mandatory breaks within words (shouldn't happen)
+        .map(|b| PdfBreakPoint {
+            at: b.pos,
+            penalty: penalty_for_break_type(b.break_type),
+            hyphen: matches!(b.break_type, BreakType::Hyphen),
+        })
+        .collect();
+    
+    // Merge with dictionary hyphenation (if applicable)
+    if needs_dictionary {
+        let dict_points = /* ... */;
+        points.extend(dict_points);
+    }
+    
+    // Fill emergency breaks for gaps
+    points = fill_pdf_emergency_break_points(stats.char_len, points);
+    
+    // ... existing token splitting logic ...
+}
+```
+
+### layout.rs Changes
+
+Add optional UAX #14-aware word iterator:
+
+```rust
+/// Iterator over words with UAX #14 break awareness.
+/// Falls back to whitespace-based breaking for simple cases.
+pub fn breakable_words_uax14(text: &str) -> BreakableWordsUax14<'_> {
+    BreakableWordsUax14::new(text)
+}
+
+pub struct BreakableWordsUax14<'a> {
+    text: &'a str,
+    // ... UAX #14 state ...
+}
+
+impl<'a> Iterator for BreakableWordsUax14<'a> {
+    type Item = &'a str;
+    
+    fn next(&mut self) -> Option<Self::Item> {
+        // Use line_break_opportunities() to find word boundaries
+        // while preserving whitespace for interword glue
+    }
+}
+```
+
+**Decision**: Keep existing `breakable_words` for backward compatibility, add `breakable_words_uax14` as opt-in.
+
+## Data Generation
+
+Generate `LB_CLASS_RANGES` from Unicode Character Database:
+
+```bash
+# Download LineBreak.txt from Unicode UCD
+curl -O https://www.unicode.org/Public/15.1.0/ucd/LineBreak.txt
+
+# Generate Rust table (script to write)
+python scripts/generate_lb_ranges.py LineBreak.txt > src/line_break_generated.rs
+```
+
+The generator script:
+1. Parses LineBreak.txt
+2. Groups contiguous code points by class
+3. Sorts ranges, merges adjacent same-class ranges
+4. Emits `static LB_CLASS_RANGES: &[(u32, u32, LineBreakClass)]`
+5. Includes `#[cfg(test)]` for table validation
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Classification tests**: Verify `line_break_class()` for key characters
+2. **Break opportunity tests**: Verify `can_break_between()` pair rules
+3. **Integration tests**: Full text → break opportunities comparison
+4. **Table validation**: Ranges sorted, non-overlapping
+
+### Golden Tests
+
+1. CJK text: "你好世界这是一个测试" → break after each character
+2. CJK + Latin: "Hello世界测试" → breaks at CJK boundaries
+3. Korean: "한글테스트" → respect syllable formation rules
+4. Quotes: `"hello world"` → no break inside quotes
+5. Numbers: "1,234.56" → no break inside number
+6. URL: "https://example.com" → break after punctuation
+
+### PDF Output Tests
+
+Render PDFs with CJK text and verify:
+- No overfull boxes
+- Line breaks occur at correct positions
+- Hyphenation works for Latin words in CJK context
+
+## Implementation Order
+
+1. **Phase 1**: Core infrastructure
+   - Add `src/line_break.rs` with `LineBreakClass` enum
+   - Implement `line_break_class()` with ASCII fast path
+   - Generate `LB_CLASS_RANGES` table
+   - Add table validation tests
+
+2. **Phase 2**: Break opportunity logic
+   - Implement `LineBreakIterator`
+   - Implement core pair rules in `can_break_between()`
+   - Add unit tests for pair rules
+
+3. **Phase 3**: pdf.rs integration
+   - Modify `flush_pdf_word` to use `line_break_opportunities()`
+   - Update `PdfBreakPoint` generation
+   - Add integration tests
+
+4. **Phase 4**: layout.rs integration
+   - Add `breakable_words_uax14` iterator
+   - Add feature flag if needed for backward compat
+   - Update documentation
+
+## Success Criteria
+
+1. CJK text renders without overflow
+2. Line breaks follow UAX #14 rules
+3. Korean syllable boundaries preserved
+4. No regression in Latin text rendering
+5. Binary size increase < 50KB
+6. All existing tests pass
+7. New UAX #14 tests pass
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Large data table size | Use range compression, only include needed classes |
+| Performance regression | ASCII fast path, profile with flamegraph |
+| Incorrect break rules | Extensive testing, compare with reference implementations |
+| Breaking change | Keep existing `breakable_words`, add new iterator |
+
+## References
+
+- [UAX #14: Unicode Line Breaking Algorithm](https://www.unicode.org/reports/tr14/)
+- [LineBreak.txt (Unicode 15.1.0)](https://www.unicode.org/Public/15.1.0/ucd/LineBreak.txt)
+- Existing `unicode_punct.rs` as data table pattern

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -22,6 +22,7 @@
 //!   expansion hooks once the baseline layout is proven.
 
 use crate::ast::Inline;
+use crate::line_break::{line_break_class, line_break_opportunities};
 use crate::text::Font;
 use std::sync::OnceLock;
 
@@ -623,22 +624,26 @@ pub fn hyphenated_paragraph_items_from_text_into<M: PairMetrics>(
     let space = measure_text_with_pairs(metrics, " ", size);
     let hyphen_width = measure_text_with_pairs(metrics, "-", size);
     while let Some(word) = words.next() {
-        hyphenator.hyphenation_points_into_scratch(
-            word,
-            HyphenationOptions::default(),
-            &mut scratch.hyphen_points,
-            &mut scratch.hyphen_lower,
-            &mut scratch.hyphen_dotted,
-            &mut scratch.hyphen_scores,
-        );
-        push_hyphenated_word_items_from_points(
-            out,
-            metrics,
-            word,
-            size,
-            hyphen_width,
-            &scratch.hyphen_points,
-        );
+        if word_contains_cjk(word) {
+            push_cjk_word_items(out, metrics, word, size);
+        } else {
+            hyphenator.hyphenation_points_into_scratch(
+                word,
+                HyphenationOptions::default(),
+                &mut scratch.hyphen_points,
+                &mut scratch.hyphen_lower,
+                &mut scratch.hyphen_dotted,
+                &mut scratch.hyphen_scores,
+            );
+            push_hyphenated_word_items_from_points(
+                out,
+                metrics,
+                word,
+                size,
+                hyphen_width,
+                &scratch.hyphen_points,
+            );
+        }
         if words.peek().is_some() {
             out.push(ParagraphItem::Glue(default_interword_glue(space)));
         }
@@ -698,6 +703,53 @@ fn push_hyphenated_word_items_from_points<M: PairMetrics>(
     }
 }
 
+fn push_cjk_word_items<M: PairMetrics>(
+    out: &mut Vec<ParagraphItem>,
+    metrics: &M,
+    word: &str,
+    size: FontSize,
+) {
+    let break_points: Vec<usize> = line_break_opportunities(word).collect();
+    if break_points.is_empty() {
+        out.push(ParagraphItem::Box(TextBox {
+            text: word.to_string(),
+            runs: StyledText::plain(word),
+            width: measure_text_with_pairs(metrics, word, size),
+        }));
+        return;
+    }
+
+    let mut start = 0usize;
+    for point in break_points {
+        if point <= start {
+            continue;
+        }
+        let part = &word[start..point];
+        if part.is_empty() {
+            continue;
+        }
+        out.push(ParagraphItem::Box(TextBox {
+            text: part.to_string(),
+            runs: StyledText::plain(part),
+            width: measure_text_with_pairs(metrics, part, size),
+        }));
+        out.push(ParagraphItem::Penalty(Penalty {
+            width: LayoutUnit::ZERO,
+            penalty: 50,
+            flagged: false,
+        }));
+        start = point;
+    }
+    if start < word.len() {
+        let part = &word[start..];
+        out.push(ParagraphItem::Box(TextBox {
+            text: part.to_string(),
+            runs: StyledText::plain(part),
+            width: measure_text_with_pairs(metrics, part, size),
+        }));
+    }
+}
+
 /// True for whitespace where normal Markdown/PDF text layout may break a line.
 ///
 /// Unicode no-break spaces are intentionally treated as word characters. They
@@ -742,6 +794,10 @@ impl<'a> Iterator for BreakableWords<'a> {
         }
         self.text.get(start..self.pos)
     }
+}
+
+fn word_contains_cjk(word: &str) -> bool {
+    word.chars().any(|c| line_break_class(c).is_cjk())
 }
 
 /// Default TeX-like interword glue for the first paragraph builder.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod fonts;
 pub mod highlight;
 pub mod html;
 pub mod layout;
+pub(crate) mod line_break;
 pub mod parse;
 pub mod pdf;
 pub mod scanner;

--- a/src/line_break.rs
+++ b/src/line_break.rs
@@ -1,0 +1,574 @@
+//! UAX #14 Unicode Line Breaking Algorithm implementation.
+//!
+//! Clean-room implementation of core line breaking rules for CJK + Latin text.
+//! Uses sorted range tables with binary search for dependency-free classification.
+
+use std::cmp::Ordering;
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum LineBreakClass {
+    BK,
+    CR,
+    LF,
+    #[allow(dead_code)]
+    NL,
+    SP,
+    #[allow(dead_code)]
+    B2,
+    #[allow(dead_code)]
+    CB,
+    ZW,
+    GL,
+    WJ,
+    Zwj,
+    ID,
+    JL,
+    JV,
+    JT,
+    H2,
+    #[allow(dead_code)]
+    H3,
+    AL,
+    NU,
+    OP,
+    CL,
+    QU,
+    #[allow(dead_code)]
+    NS,
+    IS,
+    PR,
+    PO,
+    SY,
+    HY,
+    BA,
+    #[allow(dead_code)]
+    BB,
+    EX,
+    CM,
+    XX,
+}
+
+impl LineBreakClass {
+    pub(crate) fn is_cjk(self) -> bool {
+        matches!(
+            self,
+            Self::ID | Self::JL | Self::JV | Self::JT | Self::H2 | Self::H3
+        )
+    }
+}
+
+/// Returns the UAX #14 Line Break Class for a character.
+/// ASCII fast path, then binary search in LB_CLASS_RANGES.
+#[must_use]
+pub(crate) fn line_break_class(c: char) -> LineBreakClass {
+    if c.is_ascii() {
+        return match c {
+            '\x00'..='\x09' | '\x0B'..='\x0C' => LineBreakClass::BK,
+            '\x0A' => LineBreakClass::LF,
+            '\x0D' => LineBreakClass::CR,
+            ' ' => LineBreakClass::SP,
+            '!' => LineBreakClass::EX,
+            '"' | '\'' => LineBreakClass::QU,
+            '(' | '[' | '{' | '<' => LineBreakClass::OP,
+            ')' | ']' | '}' | '>' => LineBreakClass::CL,
+            '*' | '$' | '%' => LineBreakClass::PO,
+            '+' => LineBreakClass::PR,
+            ',' => LineBreakClass::IS,
+            '-' => LineBreakClass::HY,
+            '.' => LineBreakClass::IS,
+            '/' => LineBreakClass::SY,
+            '0'..='9' => LineBreakClass::NU,
+            ':' | ';' => LineBreakClass::IS,
+            '=' => LineBreakClass::AL,
+            'A'..='Z' | 'a'..='z' | '_' => LineBreakClass::AL,
+            '\\' | '|' => LineBreakClass::BA,
+            '~' => LineBreakClass::AL,
+            '^' => LineBreakClass::PR,
+            '#' | '@' | '&' => LineBreakClass::AL,
+            _ => LineBreakClass::XX,
+        };
+    }
+
+    let cp = c as u32;
+    LB_CLASS_RANGES
+        .binary_search_by(|&(lo, hi, _)| {
+            if cp < lo {
+                Ordering::Greater
+            } else if cp > hi {
+                Ordering::Less
+            } else {
+                Ordering::Equal
+            }
+        })
+        .map(|i| LB_CLASS_RANGES[i].2)
+        .unwrap_or(LineBreakClass::XX)
+}
+
+/// Sorted, non-overlapping ranges of code points grouped by Line Break Class.
+/// Generated from Unicode 15.1.0 LineBreak.txt. Covers core CJK + Latin classes.
+/// ASCII (U+0000-U+007F) handled separately in line_break_class().
+static LB_CLASS_RANGES: &[(u32, u32, LineBreakClass)] = &[
+    // Latin-1 Supplement (U+0080-U+00FF)
+    (0x00A0, 0x00A0, LineBreakClass::GL), // NBSP
+    (0x00AD, 0x00AD, LineBreakClass::GL), // Soft hyphen
+    (0x00C0, 0x00D6, LineBreakClass::AL), // Latin-1 Supplement letters
+    (0x00D8, 0x00F6, LineBreakClass::AL), // Latin-1 Supplement letters
+    (0x00F8, 0x00FF, LineBreakClass::AL), // Latin-1 Supplement letters
+    // Latin Extended-A/B, IPA, etc. (U+0100-U+02FF)
+    (0x0100, 0x024F, LineBreakClass::AL), // Latin Extended-A/B
+    (0x0250, 0x02AF, LineBreakClass::AL), // IPA Extensions
+    (0x02B0, 0x02FF, LineBreakClass::AL), // Spacing Modifier Letters
+    // Combining Diacritical Marks (U+0300-U+036F)
+    (0x0300, 0x036F, LineBreakClass::CM),
+    // Greek and Coptic (U+0370-U+03FF)
+    (0x0370, 0x0377, LineBreakClass::AL),
+    (0x037A, 0x037F, LineBreakClass::AL),
+    (0x0384, 0x0384, LineBreakClass::AL),
+    (0x0386, 0x0386, LineBreakClass::AL),
+    (0x0388, 0x038A, LineBreakClass::AL),
+    (0x038C, 0x038C, LineBreakClass::AL),
+    (0x038E, 0x03A1, LineBreakClass::AL),
+    (0x03A3, 0x03FF, LineBreakClass::AL),
+    // Cyrillic (U+0400-U+052F)
+    (0x0400, 0x052F, LineBreakClass::AL),
+    // Armenian, Hebrew, Arabic, etc. (U+0530-U+08FF)
+    (0x0530, 0x058F, LineBreakClass::AL),
+    (0x0590, 0x05FF, LineBreakClass::AL),
+    (0x0600, 0x06FF, LineBreakClass::AL),
+    (0x0700, 0x074F, LineBreakClass::AL),
+    (0x0750, 0x077F, LineBreakClass::AL),
+    (0x0780, 0x07BF, LineBreakClass::AL),
+    (0x07C0, 0x07FF, LineBreakClass::AL),
+    (0x0800, 0x083F, LineBreakClass::AL),
+    (0x0840, 0x085F, LineBreakClass::AL),
+    (0x0860, 0x086F, LineBreakClass::AL),
+    (0x08A0, 0x08FF, LineBreakClass::AL),
+    // Devanagari and other Indic scripts (U+0900-U+0FFF)
+    (0x0900, 0x097F, LineBreakClass::AL),
+    (0x0980, 0x09FF, LineBreakClass::AL),
+    (0x0A00, 0x0A7F, LineBreakClass::AL),
+    (0x0A80, 0x0AFF, LineBreakClass::AL),
+    (0x0B00, 0x0B7F, LineBreakClass::AL),
+    (0x0B80, 0x0BFF, LineBreakClass::AL),
+    (0x0C00, 0x0C7F, LineBreakClass::AL),
+    (0x0C80, 0x0CFF, LineBreakClass::AL),
+    (0x0D00, 0x0D7F, LineBreakClass::AL),
+    (0x0D80, 0x0DFF, LineBreakClass::AL),
+    (0x0E00, 0x0E7F, LineBreakClass::AL),
+    (0x0E80, 0x0EFF, LineBreakClass::AL),
+    (0x0F00, 0x0FFF, LineBreakClass::AL),
+    // Myanmar, Georgian, Hangul Jamo (U+1000-U+11FF)
+    (0x1000, 0x109F, LineBreakClass::AL),
+    (0x10A0, 0x10FF, LineBreakClass::AL),
+    (0x1100, 0x115F, LineBreakClass::JL), // Hangul Jamo Leading
+    (0x1160, 0x11A7, LineBreakClass::JV), // Hangul Jamo Vowel
+    (0x11A8, 0x11FF, LineBreakClass::JT), // Hangul Jamo Trailing
+    // Ethiopic, Cherokee, Canadian, Ogham, Runic, etc. (U+1200-U+18FF)
+    (0x1200, 0x137F, LineBreakClass::AL),
+    (0x1380, 0x139F, LineBreakClass::AL),
+    (0x13A0, 0x13FF, LineBreakClass::AL),
+    (0x1400, 0x167F, LineBreakClass::AL),
+    (0x1680, 0x169F, LineBreakClass::AL),
+    (0x16A0, 0x16FF, LineBreakClass::AL),
+    (0x1700, 0x171F, LineBreakClass::AL),
+    (0x1720, 0x173F, LineBreakClass::AL),
+    (0x1740, 0x175F, LineBreakClass::AL),
+    (0x1760, 0x177F, LineBreakClass::AL),
+    (0x1780, 0x17FF, LineBreakClass::AL),
+    (0x1800, 0x18AF, LineBreakClass::AL),
+    (0x18B0, 0x18FF, LineBreakClass::AL),
+    // Various scripts and symbols (U+1900-U+1CFF)
+    (0x1900, 0x194F, LineBreakClass::AL),
+    (0x1950, 0x197F, LineBreakClass::AL),
+    (0x1980, 0x19DF, LineBreakClass::AL),
+    (0x19E0, 0x19FF, LineBreakClass::AL),
+    (0x1A00, 0x1A1F, LineBreakClass::AL),
+    (0x1A20, 0x1AAF, LineBreakClass::AL),
+    (0x1AB0, 0x1AFF, LineBreakClass::CM),
+    (0x1B00, 0x1B4F, LineBreakClass::AL),
+    (0x1B50, 0x1B7F, LineBreakClass::AL),
+    (0x1B80, 0x1BBF, LineBreakClass::AL),
+    (0x1BC0, 0x1BFF, LineBreakClass::AL),
+    (0x1C00, 0x1C4F, LineBreakClass::AL),
+    (0x1C50, 0x1C7F, LineBreakClass::AL),
+    (0x1C80, 0x1C8F, LineBreakClass::AL),
+    (0x1C90, 0x1CFF, LineBreakClass::AL),
+    // Phonetic Extensions, Latin Extended Additional, Greek Extended (U+1D00-U+1FFF)
+    (0x1D00, 0x1D7F, LineBreakClass::AL),
+    (0x1D80, 0x1DBF, LineBreakClass::AL),
+    (0x1DC0, 0x1DFF, LineBreakClass::CM),
+    (0x1E00, 0x1EFF, LineBreakClass::AL),
+    (0x1F00, 0x1FFF, LineBreakClass::AL),
+    // General Punctuation and symbols (U+2000-U+2BFF)
+    (0x2000, 0x200A, LineBreakClass::BA),  // Various spaces
+    (0x200B, 0x200B, LineBreakClass::ZW),  // Zero Width Space
+    (0x200C, 0x200D, LineBreakClass::Zwj), // Zero Width Non-Joiner/Joiner
+    (0x2010, 0x2010, LineBreakClass::HY),  // Hyphen
+    (0x2011, 0x2011, LineBreakClass::GL),  // Non-breaking hyphen
+    (0x2012, 0x2013, LineBreakClass::HY),  // Figure dash, en dash
+    (0x2014, 0x2015, LineBreakClass::BA),  // Em dash, horizontal bar
+    (0x2018, 0x201F, LineBreakClass::QU),  // Quotation marks
+    (0x2028, 0x2028, LineBreakClass::BK),  // Line Separator
+    (0x2029, 0x2029, LineBreakClass::BK),  // Paragraph Separator
+    (0x202F, 0x202F, LineBreakClass::GL),  // Narrow NBSP
+    (0x2030, 0x2031, LineBreakClass::PO),  // Per mille/ten thousand signs
+    (0x2032, 0x2038, LineBreakClass::PO),  // Prime marks
+    (0x2039, 0x203A, LineBreakClass::QU),  // Angle quotation marks
+    (0x2044, 0x2044, LineBreakClass::SY),  // Fraction slash
+    (0x2045, 0x2045, LineBreakClass::OP),  // Left square bracket with quill
+    (0x2046, 0x2046, LineBreakClass::CL),  // Right square bracket with quill
+    (0x2053, 0x2053, LineBreakClass::BA),  // Swung dash
+    (0x205F, 0x205F, LineBreakClass::BA),  // Medium mathematical space
+    (0x2060, 0x2060, LineBreakClass::WJ),  // Word Joiner
+    (0x2070, 0x2070, LineBreakClass::AL),  // Superscript zero
+    (0x2071, 0x2071, LineBreakClass::AL),  // Superscript i
+    (0x2074, 0x207C, LineBreakClass::AL),  // Superscript chars
+    (0x207D, 0x207D, LineBreakClass::OP),  // Superscript left parenthesis
+    (0x207E, 0x207E, LineBreakClass::CL),  // Superscript right parenthesis
+    (0x207F, 0x207F, LineBreakClass::AL),  // Superscript n
+    (0x2080, 0x208C, LineBreakClass::AL),  // Subscript chars
+    (0x208D, 0x208D, LineBreakClass::OP),  // Subscript left parenthesis
+    (0x208E, 0x208E, LineBreakClass::CL),  // Subscript right parenthesis
+    (0x2090, 0x209C, LineBreakClass::AL),  // Latin subscript small letters
+    (0x20A0, 0x20CF, LineBreakClass::PR),  // Currency symbols
+    (0x20D0, 0x20FF, LineBreakClass::CM),  // Combining Diacritical Marks for Symbols
+    (0x2100, 0x214F, LineBreakClass::AL),  // Letterlike Symbols
+    (0x2150, 0x215F, LineBreakClass::IS),  // Fractions
+    (0x2160, 0x2188, LineBreakClass::NU),  // Roman Numerals
+    (0x2190, 0x23FF, LineBreakClass::AL),  // Arrows and technical symbols
+    (0x2400, 0x24FF, LineBreakClass::AL),  // Control Pictures, OCR, Enclosed Alphanumerics
+    (0x2500, 0x27BF, LineBreakClass::AL), // Box Drawing, Block Elements, Geometric Shapes, Dingbats
+    (0x27C0, 0x2BFF, LineBreakClass::AL), // Supplemental Arrows, Braille, Mathematical Operators
+    // CJK Radicals and Symbols (U+2E80-U+2FFF)
+    (0x2E80, 0x2EFF, LineBreakClass::ID), // CJK Radicals Supplement
+    (0x2F00, 0x2FDF, LineBreakClass::ID), // Kangxi Radicals
+    (0x2FF0, 0x2FFF, LineBreakClass::ID), // Ideographic Description Characters
+    // CJK Symbols and Punctuation (U+3000-U+303F)
+    (0x3000, 0x3000, LineBreakClass::BA), // Ideographic Space
+    (0x3001, 0x3003, LineBreakClass::CL), // CJK punctuation
+    (0x3004, 0x3004, LineBreakClass::ID), // CJK punctuation
+    (0x3005, 0x3007, LineBreakClass::ID), // CJK iteration marks
+    (0x3008, 0x3008, LineBreakClass::OP), // Left angle bracket
+    (0x3009, 0x3009, LineBreakClass::CL), // Right angle bracket
+    (0x300A, 0x300A, LineBreakClass::OP), // Left double angle bracket
+    (0x300B, 0x300B, LineBreakClass::CL), // Right double angle bracket
+    (0x300C, 0x300C, LineBreakClass::OP), // Left corner bracket
+    (0x300D, 0x300D, LineBreakClass::CL), // Right corner bracket
+    (0x300E, 0x300E, LineBreakClass::OP), // Left white corner bracket
+    (0x300F, 0x300F, LineBreakClass::CL), // Right white corner bracket
+    (0x3010, 0x3010, LineBreakClass::OP), // Left black lenticular bracket
+    (0x3011, 0x3011, LineBreakClass::CL), // Right black lenticular bracket
+    (0x3012, 0x3013, LineBreakClass::ID), // CJK symbols
+    (0x3014, 0x3014, LineBreakClass::OP), // Left tortoise shell bracket
+    (0x3015, 0x3015, LineBreakClass::CL), // Right tortoise shell bracket
+    (0x3016, 0x3016, LineBreakClass::OP), // Left white lenticular bracket
+    (0x3017, 0x3017, LineBreakClass::CL), // Right white lenticular bracket
+    (0x3018, 0x3018, LineBreakClass::OP), // Left white tortoise shell bracket
+    (0x3019, 0x3019, LineBreakClass::CL), // Right white tortoise shell bracket
+    (0x301A, 0x301A, LineBreakClass::OP), // Left white square bracket
+    (0x301B, 0x301B, LineBreakClass::CL), // Right white square bracket
+    (0x301C, 0x301C, LineBreakClass::CL), // Wave dash
+    (0x301D, 0x301D, LineBreakClass::OP), // Reversed double prime quotation
+    (0x301E, 0x301F, LineBreakClass::CL), // Double prime quotation marks
+    (0x3020, 0x303E, LineBreakClass::ID), // CJK symbols
+    // Hiragana, Katakana, Bopomofo, Hangul Compatibility (U+3040-U+318F)
+    (0x3040, 0x3040, LineBreakClass::ID), // Hiragana iteration mark
+    (0x3041, 0x3096, LineBreakClass::ID), // Hiragana
+    (0x3099, 0x309A, LineBreakClass::CM), // Combining Katakana-Hiragana
+    (0x309B, 0x309C, LineBreakClass::ID), // Katakana-Hiragana sound marks
+    (0x309D, 0x309F, LineBreakClass::ID), // Hiragana iteration marks
+    (0x30A0, 0x30A0, LineBreakClass::ID), // Katakana-Hiragana double hyphen
+    (0x30A1, 0x30FA, LineBreakClass::ID), // Katakana
+    (0x30FB, 0x30FB, LineBreakClass::CL), // Katakana middle dot
+    (0x30FC, 0x30FF, LineBreakClass::ID), // Katakana extensions
+    (0x3105, 0x312F, LineBreakClass::ID), // Bopomofo
+    (0x3130, 0x318F, LineBreakClass::ID), // Hangul Compatibility Jamo
+    // CJK Extensions, Enclosed CJK, CJK Unified Ideographs (U+3190-U+9FFF)
+    (0x3190, 0x31B7, LineBreakClass::ID), // CJK radicals, Kanbun
+    (0x31C0, 0x31EF, LineBreakClass::ID), // CJK Strokes
+    (0x31F0, 0x31FF, LineBreakClass::ID), // Katakana Phonetic Extensions
+    (0x3200, 0x321E, LineBreakClass::ID), // Enclosed CJK Letters and Months
+    (0x3220, 0x3247, LineBreakClass::ID), // Enclosed CJK Letters
+    (0x3250, 0x33FF, LineBreakClass::ID), // CJK Compatibility
+    (0x3400, 0x4DBF, LineBreakClass::ID), // CJK Unified Ideographs Extension A
+    (0x4E00, 0x9FFF, LineBreakClass::ID), // CJK Unified Ideographs
+    // Yi, Hangul Syllables (U+A000-U+D7FF)
+    (0xA000, 0xA48F, LineBreakClass::ID), // Yi Syllables
+    (0xA490, 0xA4CF, LineBreakClass::ID), // Yi Radicals
+    (0xA4D0, 0xA4FF, LineBreakClass::AL), // Lisu
+    (0xA500, 0xA63F, LineBreakClass::AL), // Vai
+    (0xAC00, 0xD7A3, LineBreakClass::H2), // Hangul Syllables (most are H2)
+    (0xD7B0, 0xD7FF, LineBreakClass::ID), // Hangul Jamo Extended-B
+    // CJK Compatibility Ideographs (U+F900-U+FAFF)
+    (0xF900, 0xFAFF, LineBreakClass::ID),
+    // Variation Selectors, CJK Compatibility Forms (U+FE00-U+FE4F)
+    (0xFE00, 0xFE0F, LineBreakClass::CM), // Variation Selectors
+    (0xFE10, 0xFE16, LineBreakClass::ID), // Presentation forms
+    (0xFE17, 0xFE17, LineBreakClass::OP), // Presentation form
+    (0xFE18, 0xFE19, LineBreakClass::CL), // Presentation forms
+    (0xFE30, 0xFE4F, LineBreakClass::ID), // CJK Compatibility Forms
+    (0xFE50, 0xFE52, LineBreakClass::CL), // Small form variants
+    (0xFE54, 0xFE57, LineBreakClass::CL), // Small form variants
+    (0xFE58, 0xFE58, LineBreakClass::ID), // Small form variants
+    (0xFE59, 0xFE59, LineBreakClass::OP), // Small form variants
+    (0xFE5A, 0xFE5A, LineBreakClass::CL), // Small form variants
+    (0xFE5B, 0xFE5B, LineBreakClass::OP), // Small form variants
+    (0xFE5C, 0xFE5C, LineBreakClass::CL), // Small form variants
+    (0xFE5D, 0xFE5D, LineBreakClass::OP), // Small form variants
+    (0xFE5E, 0xFE5E, LineBreakClass::CL), // Small form variants
+    (0xFE5F, 0xFE6F, LineBreakClass::ID), // Small form variants
+    // Fullwidth ASCII variants (U+FF00-U+FFEF)
+    (0xFF01, 0xFF01, LineBreakClass::EX), // Fullwidth exclamation
+    (0xFF02, 0xFF02, LineBreakClass::QU), // Fullwidth quotation
+    (0xFF03, 0xFF05, LineBreakClass::PO), // Fullwidth symbols
+    (0xFF06, 0xFF06, LineBreakClass::AL), // Fullwidth ampersand
+    (0xFF07, 0xFF07, LineBreakClass::QU), // Fullwidth apostrophe
+    (0xFF08, 0xFF08, LineBreakClass::OP), // Fullwidth left parenthesis
+    (0xFF09, 0xFF09, LineBreakClass::CL), // Fullwidth right parenthesis
+    (0xFF0A, 0xFF0A, LineBreakClass::PO), // Fullwidth asterisk
+    (0xFF0B, 0xFF0B, LineBreakClass::PR), // Fullwidth plus
+    (0xFF0C, 0xFF0C, LineBreakClass::IS), // Fullwidth comma
+    (0xFF0D, 0xFF0D, LineBreakClass::HY), // Fullwidth hyphen
+    (0xFF0E, 0xFF0E, LineBreakClass::IS), // Fullwidth period
+    (0xFF0F, 0xFF0F, LineBreakClass::SY), // Fullwidth slash
+    (0xFF10, 0xFF19, LineBreakClass::NU), // Fullwidth digits
+    (0xFF1A, 0xFF1B, LineBreakClass::IS), // Fullwidth colon/semicolon
+    (0xFF1C, 0xFF1E, LineBreakClass::QU), // Fullwidth brackets
+    (0xFF1F, 0xFF1F, LineBreakClass::EX), // Fullwidth question
+    (0xFF20, 0xFF20, LineBreakClass::AL), // Fullwidth at sign
+    (0xFF21, 0xFF3A, LineBreakClass::AL), // Fullwidth Latin uppercase
+    (0xFF3B, 0xFF3B, LineBreakClass::OP), // Fullwidth left bracket
+    (0xFF3C, 0xFF3C, LineBreakClass::BA), // Fullwidth backslash
+    (0xFF3D, 0xFF3D, LineBreakClass::CL), // Fullwidth right bracket
+    (0xFF3E, 0xFF3E, LineBreakClass::PR), // Fullwidth caret
+    (0xFF3F, 0xFF3F, LineBreakClass::AL), // Fullwidth underscore
+    (0xFF40, 0xFF40, LineBreakClass::AL), // Fullwidth grave accent
+    (0xFF41, 0xFF5A, LineBreakClass::AL), // Fullwidth Latin lowercase
+    (0xFF5B, 0xFF5B, LineBreakClass::OP), // Fullwidth left curly bracket
+    (0xFF5C, 0xFF5C, LineBreakClass::CL), // Fullwidth right curly bracket
+    (0xFF5D, 0xFF5D, LineBreakClass::OP), // Fullwidth left white parenthesis
+    (0xFF5E, 0xFF5E, LineBreakClass::AL), // Fullwidth tilde
+    (0xFF5F, 0xFF5F, LineBreakClass::OP), // Fullwidth left white parenthesis
+    (0xFF60, 0xFF60, LineBreakClass::CL), // Fullwidth right white parenthesis
+    (0xFF61, 0xFF61, LineBreakClass::CL), // Halfwidth ideographic period
+    (0xFF62, 0xFF62, LineBreakClass::OP), // Halfwidth left corner bracket
+    (0xFF63, 0xFF63, LineBreakClass::CL), // Halfwidth right corner bracket
+    (0xFF64, 0xFF65, LineBreakClass::ID), // Halfwidth punctuation
+    (0xFF66, 0xFF6F, LineBreakClass::ID), // Halfwidth Katakana
+    (0xFF70, 0xFF70, LineBreakClass::HY), // Halfwidth prolonged sound
+    (0xFF71, 0xFF9D, LineBreakClass::ID), // Halfwidth Katakana
+    (0xFF9E, 0xFF9F, LineBreakClass::CM), // Halfwidth combining Katakana
+    (0xFFA0, 0xFFBE, LineBreakClass::JL), // Halfwidth Hangul Jamo
+    (0xFFC2, 0xFFC7, LineBreakClass::JV), // Halfwidth Hangul Vowel
+    (0xFFCA, 0xFFCF, LineBreakClass::JV), // Halfwidth Hangul Vowel
+    (0xFFD2, 0xFFD7, LineBreakClass::JV), // Halfwidth Hangul Vowel
+    (0xFFDA, 0xFFDC, LineBreakClass::JV), // Halfwidth Hangul Vowel
+    (0xFFE0, 0xFFE6, LineBreakClass::ID), // Fullwidth currency symbols
+    (0xFFE8, 0xFFEE, LineBreakClass::ID), // Halfwidth symbols
+    // Kana Supplement, Nushu (U+1B000-U+1B2FF)
+    (0x1B000, 0x1B0FF, LineBreakClass::ID), // Kana Supplement
+    (0x1B100, 0x1B12F, LineBreakClass::ID), // Kana Extended-A
+    (0x1B170, 0x1B2FF, LineBreakClass::ID), // Nushu
+    // CJK Unified Ideographs Extensions B-I, Compatibility Supplement (U+20000-U+323AF)
+    (0x20000, 0x2A6DF, LineBreakClass::ID), // CJK Unified Ideographs Extension B
+    (0x2A700, 0x2B73F, LineBreakClass::ID), // CJK Unified Ideographs Extension C
+    (0x2B740, 0x2B81F, LineBreakClass::ID), // CJK Unified Ideographs Extension D
+    (0x2B820, 0x2CEAF, LineBreakClass::ID), // CJK Unified Ideographs Extension E
+    (0x2CEB0, 0x2EBEF, LineBreakClass::ID), // CJK Unified Ideographs Extension F
+    (0x2EBF0, 0x2EE5F, LineBreakClass::ID), // CJK Unified Ideographs Extension I
+    (0x2F800, 0x2FA1F, LineBreakClass::ID), // CJK Compatibility Ideographs Supplement
+    (0x30000, 0x3134F, LineBreakClass::ID), // CJK Unified Ideographs Extension G
+    (0x31350, 0x323AF, LineBreakClass::ID), // CJK Unified Ideographs Extension H
+];
+
+/// Returns true if a line break is allowed between two characters.
+/// Implements core UAX #14 pair rules for CJK + Latin text.
+#[must_use]
+pub(crate) fn can_break_between(prev: LineBreakClass, next: LineBreakClass) -> bool {
+    match (prev, next) {
+        (LineBreakClass::BK | LineBreakClass::LF | LineBreakClass::NL, _) => true,
+        (LineBreakClass::CR, LineBreakClass::LF) => true,
+        (LineBreakClass::CR, _) => true,
+        (_, LineBreakClass::GL | LineBreakClass::WJ) => false,
+        (LineBreakClass::GL | LineBreakClass::WJ, _) => false,
+        (LineBreakClass::ZW, _) => true,
+        (_, LineBreakClass::ZW) => true,
+        (LineBreakClass::Zwj, _) => false,
+        (_, LineBreakClass::Zwj) => false,
+        (_, LineBreakClass::SP) => false,
+        (LineBreakClass::SP, _) => true,
+        (LineBreakClass::CM, _) => false,
+        (_, LineBreakClass::CM) => false,
+        (LineBreakClass::JL, LineBreakClass::JL | LineBreakClass::JV | LineBreakClass::H2) => false,
+        (
+            LineBreakClass::JV | LineBreakClass::H2,
+            LineBreakClass::JV | LineBreakClass::JT | LineBreakClass::H3,
+        ) => false,
+        (LineBreakClass::JT | LineBreakClass::H3, LineBreakClass::JT) => false,
+        (
+            LineBreakClass::ID | LineBreakClass::H2 | LineBreakClass::H3,
+            LineBreakClass::ID | LineBreakClass::H2 | LineBreakClass::H3,
+        ) => true,
+        (LineBreakClass::ID, LineBreakClass::PO) => false,
+        (LineBreakClass::PR, LineBreakClass::ID) => false,
+        (LineBreakClass::ID, LineBreakClass::AL | LineBreakClass::NU) => true,
+        (LineBreakClass::AL | LineBreakClass::NU, LineBreakClass::ID) => true,
+        (LineBreakClass::AL, LineBreakClass::AL | LineBreakClass::NU) => false,
+        (LineBreakClass::NU, LineBreakClass::NU | LineBreakClass::AL) => false,
+        (LineBreakClass::OP, LineBreakClass::AL | LineBreakClass::NU | LineBreakClass::ID) => false,
+        (LineBreakClass::AL | LineBreakClass::NU | LineBreakClass::ID, LineBreakClass::CL) => false,
+        (LineBreakClass::QU, _) => false,
+        (_, LineBreakClass::QU) => false,
+        (LineBreakClass::HY, LineBreakClass::AL | LineBreakClass::NU) => false,
+        (LineBreakClass::BA, LineBreakClass::AL | LineBreakClass::NU) => false,
+        (LineBreakClass::NS, LineBreakClass::AL | LineBreakClass::NU) => false,
+        (LineBreakClass::AL | LineBreakClass::NU, LineBreakClass::IS | LineBreakClass::SY) => false,
+        _ => true,
+    }
+}
+
+/// Iterator over line break opportunities in a string.
+pub(crate) struct LineBreakIterator<'a> {
+    chars: std::iter::Peekable<std::str::Chars<'a>>,
+    pos: usize,
+    prev_class: Option<LineBreakClass>,
+}
+
+impl<'a> LineBreakIterator<'a> {
+    pub(crate) fn new(text: &'a str) -> Self {
+        Self {
+            chars: text.chars().peekable(),
+            pos: 0,
+            prev_class: None,
+        }
+    }
+}
+
+impl Iterator for LineBreakIterator<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for c in self.chars.by_ref() {
+            let char_len = c.len_utf8();
+            let curr_class = line_break_class(c);
+
+            if let Some(prev) = self.prev_class {
+                if can_break_between(prev, curr_class) {
+                    let break_pos = self.pos;
+                    self.prev_class = Some(curr_class);
+                    self.pos += char_len;
+                    return Some(break_pos);
+                }
+            }
+
+            self.prev_class = Some(curr_class);
+            self.pos += char_len;
+        }
+        None
+    }
+}
+
+/// Returns an iterator over line break opportunities in the given text.
+/// Each returned position is a byte index where a line break may occur.
+#[must_use]
+pub(crate) fn line_break_opportunities(text: &str) -> LineBreakIterator<'_> {
+    LineBreakIterator::new(text)
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_classification() {
+        assert_eq!(line_break_class(' '), LineBreakClass::SP);
+        assert_eq!(line_break_class('a'), LineBreakClass::AL);
+        assert_eq!(line_break_class('Z'), LineBreakClass::AL);
+        assert_eq!(line_break_class('0'), LineBreakClass::NU);
+        assert_eq!(line_break_class('('), LineBreakClass::OP);
+        assert_eq!(line_break_class(')'), LineBreakClass::CL);
+        assert_eq!(line_break_class('-'), LineBreakClass::HY);
+        assert_eq!(line_break_class('/'), LineBreakClass::SY);
+    }
+
+    #[test]
+    fn cjk_classification() {
+        assert_eq!(line_break_class('中'), LineBreakClass::ID);
+        assert_eq!(line_break_class('文'), LineBreakClass::ID);
+        assert_eq!(line_break_class('あ'), LineBreakClass::ID);
+        assert_eq!(line_break_class('ア'), LineBreakClass::ID);
+        assert_eq!(line_break_class('가'), LineBreakClass::H2);
+    }
+
+    #[test]
+    fn punctuation_classification() {
+        assert_eq!(line_break_class('"'), LineBreakClass::QU);
+        assert_eq!(line_break_class('\''), LineBreakClass::QU);
+        assert_eq!(line_break_class('!'), LineBreakClass::EX);
+        assert_eq!(line_break_class(','), LineBreakClass::IS);
+    }
+
+    #[test]
+    fn ranges_sorted_and_non_overlapping() {
+        let mut prev_hi: Option<u32> = None;
+        for &(lo, hi, _) in LB_CLASS_RANGES {
+            assert!(lo <= hi, "range start must be <= end: {lo:x}-{hi:x}");
+            if let Some(p) = prev_hi {
+                assert!(
+                    lo > p,
+                    "ranges must be sorted and non-overlapping: {p:x} < {lo:x}"
+                );
+            }
+            prev_hi = Some(hi);
+        }
+    }
+
+    #[test]
+    fn zero_width_space() {
+        assert_eq!(line_break_class('\u{200B}'), LineBreakClass::ZW);
+        assert_eq!(line_break_class('\u{200C}'), LineBreakClass::Zwj);
+        assert_eq!(line_break_class('\u{200D}'), LineBreakClass::Zwj);
+    }
+
+    #[test]
+    fn break_between_cjk() {
+        assert!(can_break_between(LineBreakClass::ID, LineBreakClass::ID));
+        assert!(can_break_between(LineBreakClass::ID, LineBreakClass::AL));
+        assert!(can_break_between(LineBreakClass::AL, LineBreakClass::ID));
+        assert!(!can_break_between(LineBreakClass::AL, LineBreakClass::AL));
+    }
+
+    #[test]
+    fn break_between_hangul() {
+        assert!(!can_break_between(LineBreakClass::JL, LineBreakClass::JL));
+        assert!(!can_break_between(LineBreakClass::JL, LineBreakClass::JV));
+        assert!(!can_break_between(LineBreakClass::JV, LineBreakClass::JT));
+        assert!(can_break_between(LineBreakClass::JT, LineBreakClass::JL));
+    }
+
+    #[test]
+    fn break_iterator_latin() {
+        let text = "hello world";
+        let breaks: Vec<usize> = line_break_opportunities(text).collect();
+        assert_eq!(breaks, vec![6]);
+    }
+
+    #[test]
+    fn break_iterator_cjk() {
+        let text = "中文测试";
+        let breaks: Vec<usize> = line_break_opportunities(text).collect();
+        assert_eq!(breaks, vec![3, 6, 9]);
+    }
+
+    #[test]
+    fn break_iterator_mixed() {
+        let text = "你好world测试";
+        let breaks: Vec<usize> = line_break_opportunities(text).collect();
+        assert!(breaks.contains(&3));
+        assert!(breaks.contains(&6));
+        assert!(breaks.contains(&11));
+    }
+}

--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -29,6 +29,7 @@ use crate::layout::{
     ParagraphItem, ParagraphLayoutScratch, Penalty, TextBox, adjustment_to_layout_units,
     advance_to_layout_units, break_paragraph_into, default_interword_glue, is_breakable_whitespace,
 };
+use crate::line_break::line_break_opportunities;
 use crate::text::{Font, Kerning, Ligatures};
 use crate::theme::{Theme, ThemeColors};
 use crate::{FontAssetSlot, FontAssets, PdfOptions, RenderError};
@@ -16127,6 +16128,38 @@ struct PdfBreakPoint {
     hyphen: bool,
 }
 
+fn word_contains_cjk(word: &[Tok]) -> bool {
+    word.iter()
+        .flat_map(|tok| tok.text.chars())
+        .any(|c| crate::line_break::line_break_class(c).is_cjk())
+}
+
+fn cjk_break_points(text: &str) -> Vec<PdfBreakPoint> {
+    let mut points = Vec::new();
+    let mut char_pos = 0usize;
+    let mut byte_pos = 0usize;
+
+    for byte_break in line_break_opportunities(text) {
+        while byte_pos < byte_break {
+            let c = text[byte_pos..].chars().next();
+            if let Some(ch) = c {
+                byte_pos += ch.len_utf8();
+                char_pos += 1;
+            } else {
+                break;
+            }
+        }
+        if char_pos >= 2 && text.chars().count() - char_pos >= 2 {
+            points.push(PdfBreakPoint {
+                at: char_pos,
+                penalty: 50,
+                hyphen: false,
+            });
+        }
+    }
+    points
+}
+
 /// Characters after which a long token may break without a hyphen: URL and
 /// path punctuation plus common identifier separators.
 fn pdf_separator_break_char(c: char) -> bool {
@@ -16235,7 +16268,8 @@ fn flush_pdf_word(built: &mut BuiltParagraph, word: &mut Vec<Tok>, cx: PdfWordCo
     let stats = pdf_word_stats(word);
     let needs_dictionary = cx.policy.hyphenate && stats.ascii_alphabetic;
     let needs_synthetic_breaks = stats.char_len >= FORCED_BREAK_MIN_WORD;
-    if !needs_dictionary && !needs_synthetic_breaks {
+    let needs_cjk_breaks = word_contains_cjk(word);
+    if !needs_dictionary && !needs_synthetic_breaks && !needs_cjk_breaks {
         push_pdf_word_box(built, word, cx.fs, cx.faces, cx.width_cache);
         return;
     }
@@ -16277,6 +16311,9 @@ fn flush_pdf_word(built: &mut BuiltParagraph, word: &mut Vec<Tok>, cx: PdfWordCo
 
     let points = if needs_dictionary {
         pdf_ascii_alphabetic_word_break_points(stats.char_len, &dict_points)
+    } else if needs_cjk_breaks {
+        let plain = pdf_word_plain_text(word, stats.byte_len);
+        cjk_break_points(plain.as_ref())
     } else {
         let chars = pdf_word_chars(word, stats.char_len);
         pdf_word_break_points(&chars, &dict_points)


### PR DESCRIPTION
In case of long CJK text, the lib failed to break line. So the text will out of the right margin area.
I fixed it.